### PR TITLE
add images to product boxes

### DIFF
--- a/src/components/common/ProductBox/ProductBox.js
+++ b/src/components/common/ProductBox/ProductBox.js
@@ -11,9 +11,10 @@ import {
 import { faStar as farStar, faHeart } from '@fortawesome/free-regular-svg-icons';
 import Button from '../Button/Button';
 
-const ProductBox = ({ name, price, promo, stars, favorite, compare }) => (
+const ProductBox = ({ name, price, promo, stars, favorite, compare, photo }) => (
   <div className={styles.root}>
     <div className={styles.photo}>
+      <img src={photo} alt='' />
       {promo && <div className={styles.sale}>{promo.name}</div>}
       <div className={styles.buttons}>
         <Button variant='small'>Quick View</Button>
@@ -64,6 +65,7 @@ ProductBox.propTypes = {
   price: PropTypes.number,
   promo: PropTypes.string,
   stars: PropTypes.number,
+  photo: PropTypes.string,
 };
 
 export default ProductBox;

--- a/src/components/common/ProductBox/ProductBox.module.scss
+++ b/src/components/common/ProductBox/ProductBox.module.scss
@@ -7,7 +7,6 @@
 
   .photo {
     position: relative;
-    padding: 80% 10px 0 10px;
     background: {
       color: $gray-white-bg;
       size: contain;
@@ -26,11 +25,19 @@
       border-radius: 50%;
       color: $light-text-color;
       padding: 30px 15px 5px 15px;
-    }
+    } 
+    
 
     .buttons {
       display: flex;
       justify-content: space-between;
+    }
+
+    img {
+      object-fit: cover;
+      width: 100%;
+      height: 100%;
+      
     }
   }
 

--- a/src/redux/initialState.js
+++ b/src/redux/initialState.js
@@ -17,6 +17,8 @@ const initialState = {
       newFurniture: true,
       favorite: true,
       compare: true,
+      photo:
+        'https://images.pexels.com/photos/3316925/pexels-photo-3316925.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940',
     },
     {
       id: 'aenean-ru-bristique-2',
@@ -26,6 +28,8 @@ const initialState = {
       stars: 2,
       newFurniture: true,
       favorite: true,
+      photo:
+        'https://images.pexels.com/photos/916337/pexels-photo-916337.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940',
     },
     {
       id: 'aenean-ru-bristique-3',
@@ -36,6 +40,8 @@ const initialState = {
       promo: { name: 'sale', discount: 15 },
       newFurniture: true,
       compare: true,
+      photo:
+        'https://images.pexels.com/photos/1148955/pexels-photo-1148955.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940',
     },
     {
       id: 'aenean-ru-bristique-4',
@@ -44,6 +50,8 @@ const initialState = {
       price: 30,
       stars: 2,
       newFurniture: true,
+      photo:
+        'https://images.pexels.com/photos/2082092/pexels-photo-2082092.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940',
     },
     {
       id: 'aenean-ru-bristique-5',
@@ -53,6 +61,8 @@ const initialState = {
       stars: 2,
       promo: { name: 'sale', discount: 10 },
       newFurniture: true,
+      photo:
+        'https://images.pexels.com/photos/3558644/pexels-photo-3558644.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940',
     },
     {
       id: 'aenean-ru-bristique-6',
@@ -62,6 +72,8 @@ const initialState = {
       stars: 2,
       promo: { name: 'sale', discount: 10 },
       newFurniture: true,
+      photo:
+        'https://images.pexels.com/photos/3190541/pexels-photo-3190541.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940',
     },
     {
       id: 'aenean-ru-bristique-7',
@@ -71,6 +83,8 @@ const initialState = {
       stars: 2,
       promo: { name: 'sale', discount: 25 },
       newFurniture: true,
+      photo:
+        'https://images.pexels.com/photos/2995012/pexels-photo-2995012.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940',
     },
     {
       id: 'aenean-ru-bristique-8',
@@ -80,6 +94,8 @@ const initialState = {
       stars: 2,
       promo: { name: 'sale', discount: 25 },
       newFurniture: true,
+      photo:
+        'https://images.pexels.com/photos/3316925/pexels-photo-3316925.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=960',
     },
     {
       id: 'aenean-ru-bristique-9',
@@ -89,6 +105,8 @@ const initialState = {
       stars: 2,
       promo: { name: 'sale', discount: 25 },
       newFurniture: true,
+      photo:
+        'https://images.pexels.com/photos/2995012/pexels-photo-2995012.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940',
     },
     {
       id: 'aenean-ru-bristique-10',
@@ -98,6 +116,8 @@ const initialState = {
       stars: 2,
       promo: { name: 'sale', discount: 25 },
       newFurniture: true,
+      photo:
+        'https://images.pexels.com/photos/916337/pexels-photo-916337.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940',
     },
     {
       id: 'aenean-ru-bristique-11',
@@ -107,6 +127,8 @@ const initialState = {
       stars: 2,
       promo: { name: 'sale', discount: 25 },
       newFurniture: true,
+      photo:
+        'https://images.pexels.com/photos/1148955/pexels-photo-1148955.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940',
     },
     {
       id: 'aenean-ru-bristique-12',
@@ -116,6 +138,8 @@ const initialState = {
       stars: 2,
       promo: { name: 'sale', discount: 25 },
       newFurniture: true,
+      photo:
+        'https://images.pexels.com/photos/2082092/pexels-photo-2082092.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940',
     },
     {
       id: 'aenean-ru-bristique-13',
@@ -125,6 +149,8 @@ const initialState = {
       stars: 2,
       promo: { name: 'sale', discount: 25 },
       newFurniture: true,
+      photo:
+        'https://images.pexels.com/photos/3558644/pexels-photo-3558644.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940',
     },
     {
       id: 'aenean-ru-bristique-14',
@@ -134,6 +160,8 @@ const initialState = {
       stars: 2,
       promo: { name: 'sale', discount: 25 },
       newFurniture: true,
+      photo:
+        'https://images.pexels.com/photos/3190541/pexels-photo-3190541.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940',
     },
     {
       id: 'aenean-ru-bristique-15',
@@ -143,6 +171,8 @@ const initialState = {
       stars: 2,
       promo: { name: 'sale', discount: 25 },
       newFurniture: true,
+      photo:
+        'https://images.pexels.com/photos/2995012/pexels-photo-2995012.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940',
     },
     {
       id: 'aenean-ru-bristique-16',
@@ -152,6 +182,8 @@ const initialState = {
       stars: 2,
       promo: { name: 'sale', discount: 25 },
       newFurniture: true,
+      photo:
+        'https://images.pexels.com/photos/3316925/pexels-photo-3316925.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=960',
     },
     {
       id: 'aenean-ru-bristique-17',
@@ -161,6 +193,8 @@ const initialState = {
       stars: 2,
       promo: { name: 'sale', discount: 25 },
       newFurniture: true,
+      photo:
+        'https://images.pexels.com/photos/3190541/pexels-photo-3190541.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940',
     },
     {
       id: 'aenean-ru-bristique-18',
@@ -170,6 +204,8 @@ const initialState = {
       stars: 2,
       promo: { name: 'sale', discount: 25 },
       newFurniture: true,
+      photo:
+        'https://images.pexels.com/photos/916337/pexels-photo-916337.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940',
     },
     {
       id: 'aenean-ru-bristique-19',
@@ -179,6 +215,8 @@ const initialState = {
       stars: 2,
       promo: { name: 'sale', discount: 25 },
       newFurniture: true,
+      photo:
+        'https://images.pexels.com/photos/1148955/pexels-photo-1148955.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940',
     },
     {
       id: 'aenean-ru-bristique-20',
@@ -188,6 +226,8 @@ const initialState = {
       stars: 2,
       promo: { name: 'sale', discount: 25 },
       newFurniture: true,
+      photo:
+        'https://images.pexels.com/photos/2082092/pexels-photo-2082092.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940',
     },
     {
       id: 'aenean-ru-bristique-21',
@@ -197,6 +237,8 @@ const initialState = {
       stars: 2,
       promo: { name: 'sale', discount: 25 },
       newFurniture: true,
+      photo:
+        'https://images.pexels.com/photos/3558644/pexels-photo-3558644.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940',
     },
     {
       id: 'aenean-ru-bristique-22',
@@ -206,6 +248,8 @@ const initialState = {
       stars: 2,
       promo: { name: 'sale', discount: 25 },
       newFurniture: true,
+      photo:
+        'https://images.pexels.com/photos/3190541/pexels-photo-3190541.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940',
     },
     {
       id: 'aenean-ru-bristique-23',
@@ -215,6 +259,8 @@ const initialState = {
       stars: 2,
       promo: { name: 'sale', discount: 25 },
       newFurniture: true,
+      photo:
+        'https://images.pexels.com/photos/2995012/pexels-photo-2995012.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940',
     },
     {
       id: 'aenean-ru-bristique-24',
@@ -224,6 +270,8 @@ const initialState = {
       stars: 2,
       promo: { name: 'sale', discount: 25 },
       newFurniture: true,
+      photo:
+        'https://images.pexels.com/photos/916337/pexels-photo-916337.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940',
     },
   ],
   cart: {


### PR DESCRIPTION
Na stronie nie ma zdjęć w boksach produktów, bo w designie ich też nie było. Klient poprosił nas jednak, aby wstawić jakieś przykładowe zdjęcia, najlepiej mebli. Trzeba znaleźć jakieś w sieci.

Zdjęcia powinny być różnych rozmiarów i proporcji, i tak ostylowane żeby wypełniały całą przestrzeń przeznaczoną na zdjęcie (czyli w trybie cover).